### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - develop
+  pull_request:
 jobs:
   build:
     name: 🏗 Build
@@ -11,18 +12,11 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-      - name: 🔑 Get cache directory
-        id: yarn-cache-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: 💾 Cache modules
-        uses: actions/cache@v2
-        id: yarn-cache
+      - name: Setup node
+        uses: actions/setup-node@v2
         with:
-          path: ${{ steps.yarn-cache-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: "16"
+          cache: "yarn"
       - name: 📦 Install packages
         run: yarn install
       - name: 🏗 Build assets


### PR DESCRIPTION
- make better use of the `setup-node` action options
- run build (but not publish) on pull requests